### PR TITLE
Fix wrong error message in installer

### DIFF
--- a/static/installer.php
+++ b/static/installer.php
@@ -34,7 +34,7 @@ namespace
     // check version
     check(
         'You have a supported version of PHP (>= 7.2.5).',
-        'You need PHP 5.6 or greater.',
+        'You need PHP 7.2.5 or greater.',
         function () {
             return version_compare(PHP_VERSION, '7.2.5', '>=');
         }


### PR DESCRIPTION
Hello!  
This is a small PR but I think this is worth fixing - the installer checks for PHP 7.2.5 and spits an error message with PHP 5.6, which puzzled me when I tried to install it in a PHP 5.6 environment